### PR TITLE
fix: Correct usage of pow function to resolve build failure

### DIFF
--- a/app/src/main/java/com/media/guardian/screens/DetailScreen.kt
+++ b/app/src/main/java/com/media/guardian/screens/DetailScreen.kt
@@ -44,6 +44,7 @@ import androidx.navigation.NavController
 import coil.compose.AsyncImage
 import com.media.guardian.ui.composables.VideoPlayer
 import com.media.guardian.viewmodel.MediaViewModel
+import kotlin.math.pow
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
@@ -208,7 +209,7 @@ private fun formatFileSize(sizeInBytes: Long): String {
     if (sizeInBytes <= 0) return "0 B"
     val units = arrayOf("B", "KB", "MB", "GB", "TB")
     val digitGroups = (kotlin.math.log10(sizeInBytes.toDouble()) / kotlin.math.log10(1024.0)).toInt()
-    return String.format(java.util.Locale.US, "%.1f %s", sizeInBytes / kotlin.math.pow(1024.0, digitGroups.toDouble()), units[digitGroups])
+    return String.format(java.util.Locale.US, "%.1f %s", sizeInBytes / 1024.0.pow(digitGroups), units[digitGroups])
 }
 
 private fun formatTimestamp(timestamp: Long): String {


### PR DESCRIPTION
The previous build was failing with an `Unresolved reference: pow` error in `DetailScreen.kt`.

This was caused by an incorrect call to `kotlin.math.pow`. The `pow` function is an extension function on `Double` and `Float`, not a top-level function in the `kotlin.math` package.

This commit corrects the call from `kotlin.math.pow(1024.0, ...)` to `1024.0.pow(...)` and adds the required `kotlin.math.pow` import. This resolves the compilation error.